### PR TITLE
Fixing the extra layout inflations

### DIFF
--- a/box-share-sdk/src/main/java/com/box/androidsdk/share/adapters/CollaboratorsAdapter.java
+++ b/box-share-sdk/src/main/java/com/box/androidsdk/share/adapters/CollaboratorsAdapter.java
@@ -51,14 +51,16 @@ public class CollaboratorsAdapter extends BaseAdapter {
 
     @Override
     public View getView(int position, View convertView, ViewGroup parent) {
-        View rowView = LayoutInflater.from(mContext).inflate(R.layout.list_item_collaboration, parent, false);
-        ViewHolder holder = (ViewHolder) rowView.getTag();
-        if (holder == null) {
+        ViewHolder holder;
+        if (convertView == null) {
+            convertView = LayoutInflater.from(mContext).inflate(R.layout.list_item_collaboration, parent, false);
             holder = new ViewHolder();
-            holder.nameView = (TextView) rowView.findViewById(R.id.collaborator_role_title);
-            holder.roleView = (TextView) rowView.findViewById(R.id.collaborator_role);
-            holder.initialsView = (TextView) rowView.findViewById(R.id.collaborator_initials);
-            rowView.setTag(holder);
+            holder.nameView = (TextView) convertView.findViewById(R.id.collaborator_role_title);
+            holder.roleView = (TextView) convertView.findViewById(R.id.collaborator_role);
+            holder.initialsView = (TextView) convertView.findViewById(R.id.collaborator_initials);
+            convertView.setTag(holder);
+        } else {
+            holder = (ViewHolder) convertView.getTag();
         }
         BoxCollaboration collaboration = mItems.get(position);
         if (collaboration != null) {
@@ -79,7 +81,7 @@ public class CollaboratorsAdapter extends BaseAdapter {
             holder.roleView.setText(description);
         }
 
-        return rowView;
+        return convertView;
     }
 
     public synchronized void setItems(Collection<BoxCollaboration> items) {


### PR DESCRIPTION
Layout should only be inflated if the passed in convertView is null. If the view is recycled, layout doesn't need to be inflated. Removing the extra inflation will improve performance.