### PR TITLE
Correct error message for partial success adding collaborators

### DIFF
--- a/box-share-sdk/src/main/java/com/box/androidsdk/share/api/BoxShareController.java
+++ b/box-share-sdk/src/main/java/com/box/androidsdk/share/api/BoxShareController.java
@@ -185,11 +185,11 @@ public class BoxShareController implements ShareController {
     public BoxFutureTask<BoxCollaborationItem> fetchRoles(BoxCollaborationItem boxCollaborationItem) {
         BoxRequest request = null;
         if (boxCollaborationItem instanceof BoxFile) {
-            request = mFileApi.getInfoRequest(boxCollaborationItem.getId()).setFields(BoxFolder.FIELD_ALLOWED_INVITEE_ROLES, BoxCollaborationItem.FIELD_DEFAULT_INVITEE_ROLE);
+            request = mFileApi.getInfoRequest(boxCollaborationItem.getId()).setFields(BoxFolder.FIELD_ALLOWED_INVITEE_ROLES, BoxCollaborationItem.FIELD_DEFAULT_INVITEE_ROLE, BoxFolder.FIELD_PERMISSIONS);
 
         }
         if (boxCollaborationItem instanceof BoxFolder){
-            request = mFolderApi.getInfoRequest(boxCollaborationItem.getId()).setFields(BoxFolder.FIELD_ALLOWED_INVITEE_ROLES, BoxCollaborationItem.FIELD_DEFAULT_INVITEE_ROLE);
+            request = mFolderApi.getInfoRequest(boxCollaborationItem.getId()).setFields(BoxFolder.FIELD_ALLOWED_INVITEE_ROLES, BoxCollaborationItem.FIELD_DEFAULT_INVITEE_ROLE, BoxFolder.FIELD_PERMISSIONS);
         }
         if (request == null){
             BoxLogUtils.nonFatalE("BoxShareController","unhandled type " + boxCollaborationItem, new RuntimeException("bad argument"));

--- a/box-share-sdk/src/main/java/com/box/androidsdk/share/fragments/InviteCollaboratorsFragment.java
+++ b/box-share-sdk/src/main/java/com/box/androidsdk/share/fragments/InviteCollaboratorsFragment.java
@@ -94,7 +94,6 @@ public class InviteCollaboratorsFragment extends BoxFragment implements View.OnC
 
         // Get serialized roles or fetch them if they are not available
         if (getCollaborationItem() != null && getCollaborationItem().getAllowedInviteeRoles() != null) {
-            System.out.println("aaa " + getCollaborationItem() +  " " + getCollaborationItem().getPermissions() );
             if(getCollaborationItem().getPermissions().contains(BoxItem.Permission.CAN_INVITE_COLLABORATOR)) {
                 mRoles = getCollaborationItem().getAllowedInviteeRoles();
                 BoxCollaboration.Role defaultRole = getBestDefaultRole(getCollaborationItem().getDefaultInviteeRole(), mRoles);

--- a/box-share-sdk/src/main/java/com/box/androidsdk/share/fragments/InviteCollaboratorsFragment.java
+++ b/box-share-sdk/src/main/java/com/box/androidsdk/share/fragments/InviteCollaboratorsFragment.java
@@ -94,6 +94,7 @@ public class InviteCollaboratorsFragment extends BoxFragment implements View.OnC
 
         // Get serialized roles or fetch them if they are not available
         if (getCollaborationItem() != null && getCollaborationItem().getAllowedInviteeRoles() != null) {
+            System.out.println("aaa " + getCollaborationItem() +  " " + getCollaborationItem().getPermissions() );
             if(getCollaborationItem().getPermissions().contains(BoxItem.Permission.CAN_INVITE_COLLABORATOR)) {
                 mRoles = getCollaborationItem().getAllowedInviteeRoles();
                 BoxCollaboration.Role defaultRole = getBestDefaultRole(getCollaborationItem().getDefaultInviteeRole(), mRoles);
@@ -404,7 +405,7 @@ public class InviteCollaboratorsFragment extends BoxFragment implements View.OnC
                 BoxItem boxItem = (BoxItem) getArguments().getSerializable(CollaborationUtils.EXTRA_ITEM);
                 String itemType = getItemType(boxItem);
 
-                msg = String.format(getString(R.string.box_sharesdk_num_collaborators_error), collaborators.toString(), itemType);
+                msg = String.format(getString(R.string.box_sharesdk_following_collaborators_error), collaborators.toString());
 
             } else if (alreadyAddedCount == 1) {
                 msg = String.format(getString(R.string.box_sharesdk_has_already_been_invited), name);


### PR DESCRIPTION
New message for failed invites:
"The following collaborators could not be invited: example1@foobar.com, example2@foobar.com, example3@foo..."

In addition, we added the permissions field to the fetch file/folder request for the collaborated item. This fixes a crash when the use rotated the device while on the share collaboration activity.