### PR TITLE
Fix a bug where rotating causes previous state to be lost. Also fixes…

### DIFF
--- a/box-share-sdk/src/main/java/com/box/androidsdk/share/api/BoxShareController.java
+++ b/box-share-sdk/src/main/java/com/box/androidsdk/share/api/BoxShareController.java
@@ -51,9 +51,9 @@ public class BoxShareController implements ShareController {
     private String[] mFileShareFields;
     private String[] mBookmarkShareFields;
     private static String[] REQUIRED_COLLABORATION_FIELDS = new String[]{
-            BoxFolder.FIELD_ALLOWED_INVITEE_ROLES,
+            BoxCollaborationItem.FIELD_ALLOWED_INVITEE_ROLES,
             BoxCollaborationItem.FIELD_DEFAULT_INVITEE_ROLE,
-            BoxItem.FIELD_PERMISSIONS,
+            BoxCollaborationItem.FIELD_PERMISSIONS,
             BoxCollaborationItem.FIELD_OWNED_BY
     };
 

--- a/box-share-sdk/src/main/java/com/box/androidsdk/share/api/BoxShareController.java
+++ b/box-share-sdk/src/main/java/com/box/androidsdk/share/api/BoxShareController.java
@@ -50,6 +50,12 @@ public class BoxShareController implements ShareController {
     private String[] mFolderShareFields;
     private String[] mFileShareFields;
     private String[] mBookmarkShareFields;
+    private static String[] REQUIRED_COLLABORATION_FIELDS = new String[]{
+            BoxFolder.FIELD_ALLOWED_INVITEE_ROLES,
+            BoxCollaborationItem.FIELD_DEFAULT_INVITEE_ROLE,
+            BoxItem.FIELD_PERMISSIONS,
+            BoxCollaborationItem.FIELD_OWNED_BY
+    };
 
     public BoxShareController(BoxSession session) {
         mSession = session;
@@ -185,11 +191,10 @@ public class BoxShareController implements ShareController {
     public BoxFutureTask<BoxCollaborationItem> fetchRoles(BoxCollaborationItem boxCollaborationItem) {
         BoxRequest request = null;
         if (boxCollaborationItem instanceof BoxFile) {
-            request = mFileApi.getInfoRequest(boxCollaborationItem.getId()).setFields(BoxFolder.FIELD_ALLOWED_INVITEE_ROLES, BoxCollaborationItem.FIELD_DEFAULT_INVITEE_ROLE, BoxFolder.FIELD_PERMISSIONS);
-
+            request = mFileApi.getInfoRequest(boxCollaborationItem.getId()).setFields(REQUIRED_COLLABORATION_FIELDS);
         }
         if (boxCollaborationItem instanceof BoxFolder){
-            request = mFolderApi.getInfoRequest(boxCollaborationItem.getId()).setFields(BoxFolder.FIELD_ALLOWED_INVITEE_ROLES, BoxCollaborationItem.FIELD_DEFAULT_INVITEE_ROLE, BoxFolder.FIELD_PERMISSIONS);
+            request = mFolderApi.getInfoRequest(boxCollaborationItem.getId()).setFields(REQUIRED_COLLABORATION_FIELDS);
         }
         if (request == null){
             BoxLogUtils.nonFatalE("BoxShareController","unhandled type " + boxCollaborationItem, new RuntimeException("bad argument"));

--- a/box-share-sdk/src/main/java/com/box/androidsdk/share/fragments/CollaborationsFragment.java
+++ b/box-share-sdk/src/main/java/com/box/androidsdk/share/fragments/CollaborationsFragment.java
@@ -60,16 +60,22 @@ public class CollaborationsFragment extends BoxFragment implements AdapterView.O
         mNoCollaboratorsText = (TextView) view.findViewById(R.id.no_collaborators_text);
 
         if (savedInstanceState == null) {
+            if (getArguments() != null){
+                Bundle args = getArguments();
+                mCollaborations = (BoxIteratorCollaborations)args.getSerializable(CollaborationUtils.EXTRA_COLLABORATIONS);
+            }
+            if (mCollaborations != null){
+                updateUi();
+            }
             fetchCollaborations();
-        } else if (savedInstanceState != null) {
+
+        } else {
             mCollaborations = (BoxIteratorCollaborations)savedInstanceState.getSerializable(CollaborationUtils.EXTRA_COLLABORATIONS);
             updateUi();
-        } else if (getArguments() != null){
-            Bundle args = getArguments();
-            mCollaborations = (BoxIteratorCollaborations)args.getSerializable(CollaborationUtils.EXTRA_COLLABORATIONS);
-            updateUi();
+            if (mCollaborations == null) {
+                fetchCollaborations();
+            }
         }
-
         // Get serialized roles or fetch them if they are not available
         if (getItem().getAllowedInviteeRoles() == null) {
             fetchRoles();

--- a/box-share-sdk/src/main/java/com/box/androidsdk/share/fragments/CollaborationsFragment.java
+++ b/box-share-sdk/src/main/java/com/box/androidsdk/share/fragments/CollaborationsFragment.java
@@ -61,12 +61,12 @@ public class CollaborationsFragment extends BoxFragment implements AdapterView.O
 
         if (savedInstanceState == null) {
             fetchCollaborations();
-        }else if (getArguments() != null) {
+        }else if (savedInstanceState != null) {
+            mCollaborations = (BoxIteratorCollaborations)savedInstanceState.getSerializable(CollaborationUtils.EXTRA_COLLABORATIONS);
+            updateUi();
+        } else if (getArguments() != null){
             Bundle args = getArguments();
             mCollaborations = (BoxIteratorCollaborations)args.getSerializable(CollaborationUtils.EXTRA_COLLABORATIONS);
-            updateUi();
-        }else {
-            mCollaborations = (BoxIteratorCollaborations)savedInstanceState.getSerializable(CollaborationUtils.EXTRA_COLLABORATIONS);
             updateUi();
         }
 
@@ -74,7 +74,6 @@ public class CollaborationsFragment extends BoxFragment implements AdapterView.O
         if (getItem().getAllowedInviteeRoles() == null) {
             fetchRoles();
         }
-
         return view;
     }
 

--- a/box-share-sdk/src/main/java/com/box/androidsdk/share/fragments/CollaborationsFragment.java
+++ b/box-share-sdk/src/main/java/com/box/androidsdk/share/fragments/CollaborationsFragment.java
@@ -61,7 +61,7 @@ public class CollaborationsFragment extends BoxFragment implements AdapterView.O
 
         if (savedInstanceState == null) {
             fetchCollaborations();
-        }else if (savedInstanceState != null) {
+        } else if (savedInstanceState != null) {
             mCollaborations = (BoxIteratorCollaborations)savedInstanceState.getSerializable(CollaborationUtils.EXTRA_COLLABORATIONS);
             updateUi();
         } else if (getArguments() != null){

--- a/box-share-sdk/src/main/java/com/box/androidsdk/share/fragments/InviteCollaboratorsFragment.java
+++ b/box-share-sdk/src/main/java/com/box/androidsdk/share/fragments/InviteCollaboratorsFragment.java
@@ -20,6 +20,7 @@ import com.box.androidsdk.content.BoxException;
 import com.box.androidsdk.content.BoxFutureTask;
 import com.box.androidsdk.content.models.BoxCollaboration;
 import com.box.androidsdk.content.models.BoxCollaborationItem;
+import com.box.androidsdk.content.models.BoxCollaborator;
 import com.box.androidsdk.content.models.BoxFile;
 import com.box.androidsdk.content.models.BoxFolder;
 import com.box.androidsdk.content.models.BoxItem;
@@ -64,6 +65,8 @@ public class InviteCollaboratorsFragment extends BoxFragment implements View.OnC
     private static final Integer MY_PERMISSIONS_REQUEST_READ_CONTACTS = 32;
     public static final String TAG = InviteCollaboratorsFragment.class.getName();
     public static final String EXTRA_USE_CONTACTS_PROVIDER = "InviteCollaboratorsFragment.ExtraUseContactsProvider";
+    public static final String EXTRA_COLLAB_SELECTED_ROLE = "collabSelectedRole";
+
     private Button mRoleButton;
     private ChipCollaborationView mAutoComplete;
     private InviteeAdapter mAdapter;
@@ -91,13 +94,23 @@ public class InviteCollaboratorsFragment extends BoxFragment implements View.OnC
 
         mCollabInitialsView = (CollaboratorsInitialsView) view.findViewById(R.id.collaboratorsInitialsView);
         mCollabInitialsView.setArguments((BoxCollaborationItem)mShareItem, mController);
+        if (savedInstanceState != null){
+            String selected_role_enum = savedInstanceState.getString(EXTRA_COLLAB_SELECTED_ROLE);
+            if (selected_role_enum != null){
+                mSelectedRole = BoxCollaboration.Role.fromString(selected_role_enum);
+            }
+        }
 
         // Get serialized roles or fetch them if they are not available
         if (getCollaborationItem() != null && getCollaborationItem().getAllowedInviteeRoles() != null) {
             if(getCollaborationItem().getPermissions().contains(BoxItem.Permission.CAN_INVITE_COLLABORATOR)) {
                 mRoles = getCollaborationItem().getAllowedInviteeRoles();
-                BoxCollaboration.Role defaultRole = getBestDefaultRole(getCollaborationItem().getDefaultInviteeRole(), mRoles);
-                setSelectedRole(defaultRole);
+                if (mSelectedRole == null){
+                    BoxCollaboration.Role defaultRole = getBestDefaultRole(getCollaborationItem().getDefaultInviteeRole(), mRoles);
+                    setSelectedRole(defaultRole);
+                } else {
+                    setSelectedRole(mSelectedRole);
+                }
             } else {
                 showNoPermissionToast();
                 getActivity().finish();
@@ -121,6 +134,14 @@ public class InviteCollaboratorsFragment extends BoxFragment implements View.OnC
             BoxLogUtils.e("invalid role name " + roleName, e);
             return roles.get(0);
         }
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        if (mSelectedRole != null) {
+            outState.putString(EXTRA_COLLAB_SELECTED_ROLE, mSelectedRole.toString());
+        }
+        super.onSaveInstanceState(outState);
     }
 
     /**

--- a/box-share-sdk/src/main/java/com/box/androidsdk/share/fragments/InviteCollaboratorsFragment.java
+++ b/box-share-sdk/src/main/java/com/box/androidsdk/share/fragments/InviteCollaboratorsFragment.java
@@ -94,7 +94,7 @@ public class InviteCollaboratorsFragment extends BoxFragment implements View.OnC
 
         mCollabInitialsView = (CollaboratorsInitialsView) view.findViewById(R.id.collaboratorsInitialsView);
         mCollabInitialsView.setArguments((BoxCollaborationItem)mShareItem, mController);
-        if (savedInstanceState != null){
+        if (savedInstanceState != null) {
             String selected_role_enum = savedInstanceState.getString(EXTRA_COLLAB_SELECTED_ROLE);
             if (selected_role_enum != null){
                 mSelectedRole = BoxCollaboration.Role.fromString(selected_role_enum);
@@ -105,7 +105,7 @@ public class InviteCollaboratorsFragment extends BoxFragment implements View.OnC
         if (getCollaborationItem() != null && getCollaborationItem().getAllowedInviteeRoles() != null) {
             if(getCollaborationItem().getPermissions().contains(BoxItem.Permission.CAN_INVITE_COLLABORATOR)) {
                 mRoles = getCollaborationItem().getAllowedInviteeRoles();
-                if (mSelectedRole == null){
+                if (mSelectedRole == null) {
                     BoxCollaboration.Role defaultRole = getBestDefaultRole(getCollaborationItem().getDefaultInviteeRole(), mRoles);
                     setSelectedRole(defaultRole);
                 } else {


### PR DESCRIPTION
… a crash when allowed invitee roles are fetched, if a user chooses a given collaborator the owned by status is unavailable.